### PR TITLE
Fix description property in Cursor

### DIFF
--- a/trino/dbapi.py
+++ b/trino/dbapi.py
@@ -209,7 +209,7 @@ class Cursor(object):
 
     @property
     def description(self):
-        if self._query.columns is None:
+        if not hasattr(self._query, 'columns') or self._query.columns is None:
             return None
 
         # [ (name, type_code, display_size, internal_size, precision, scale, null_ok) ]


### PR DESCRIPTION
it is needed when trying to pass the connection object to pandas.read_sql_query. If it is not added you will encounter this error:
```
AttributeError: 'NoneType' object has no attribute 'columns'
```